### PR TITLE
Correct spelling error in VeracityIntegrationConfigService

### DIFF
--- a/Veracity.Authentication.OpenIDConnect.Core/VeracityIntegrationConfigService.cs
+++ b/Veracity.Authentication.OpenIDConnect.Core/VeracityIntegrationConfigService.cs
@@ -5,12 +5,14 @@ namespace Veracity.Authentication.OpenIDConnect.Core
 {
     public class VeracityIntegrationConfigService : IVeracityIntegrationConfigService
     {
+        public const string SectionKey = "VeracityIntegration";
+
         private readonly VeracityIntegrationOptions _azureAdB2COptions;
         public VeracityIntegrationConfigService(IConfiguration configuration)
         {
             _azureAdB2COptions = new VeracityIntegrationOptions();
-            configuration.GetValue<VeracityIntegrationOptions>("VeracityIntegtaion");
-            configuration.GetSection("VeracityIntegtaion").Bind(_azureAdB2COptions);
+            configuration.GetValue<VeracityIntegrationOptions>(SectionKey);
+            configuration.GetSection(SectionKey).Bind(_azureAdB2COptions);
         }
 
         public VeracityIntegrationOptions GetVeracityIntegrationConfig()


### PR DESCRIPTION
Fixes #1 
This is a breaking change. Projects using this library must update the section key in the appsettings.json files.